### PR TITLE
Add tooltip & autocomplete to language and license

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,8 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
-    <title></title>
+    <title>Awesome-Selfhosted Helper</title>
     <meta charset="utf-8" />
-    <!--<link href="style.css" rel="stylesheet" />-->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
 </head>
 
@@ -34,7 +33,7 @@
                     </div>
                     <div class="custom-control custom-radio custom-control-inline form-control-lg">
                         <input type="radio" id="nonfree" name="free" class="custom-control-input" onkeyup="formChanged()" onchange="formChanged()" value="nonfree" />
-                        <Label class="custom-control-label" for="nonfree">Non-Free/Proprietary</Label> 
+                        <Label class="custom-control-label" for="nonfree">Non-Free/Proprietary</Label>
                     </div>
 
                 <div class="form-row">
@@ -57,7 +56,7 @@
                     <div class="form-group col">
                         <input type="text" class="form-control" name="demo" id="demo" onkeyup="formChanged()" onchange="formChanged()" placeholder="Demo Link" />
                         <label class="sr-only" for="demo">Demo</label>
-                    </div>                    
+                    </div>
                     <div class="form-group col">
                         <input type="text" class="form-control" name="sourcecode" id="source" onkeyup="formChanged()" onchange="formChanged()" placeholder="Source Code Link" />
                         <label class="sr-only" for="source">Source Code</label>
@@ -69,11 +68,11 @@
                         <label class="sr-only" for="clients">Clients</label>
                     </div>
                     <div class="form-group col-3">
-                        <input type="text" class="form-control" name="license" id="license" onkeyup="formChanged()" onchange="formChanged()" placeholder="License"/>
+                        <input type="text" class="form-control" title="The suggestions follow Awesome Selfhosted's standards but but may not cover all cases." name="license" id="license" onkeyup="formChanged()" onchange="formChanged()" placeholder="License"/>
                         <label class="sr-only" for="license">License</label>
                     </div>
                     <div class="form-group col-3">
-                        <input type="text" class="form-control" name="language" id="language" onkeyup="formChanged()" onchange="formChanged()" placeholder="Language" required />
+                        <input type="text" class="form-control" title="The suggestions follow Awesome Selfhosted's standards but but may not cover all cases." name="language" id="language" onkeyup="formChanged()" onchange="formChanged()" placeholder="Language" required />
                         <label class="sr-only" for="language">Language</label>
                     </div>
                 </div>
@@ -96,5 +95,7 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 </body>
 </html>

--- a/script2.js
+++ b/script2.js
@@ -11,7 +11,80 @@ function formChanged() {
     var pdep = document.getElementById("propdep").checked;
     var nonfree = document.getElementById("nonfree").checked;
     var free = document.getElementById("free").checked;
-    
+
+    $( document ).tooltip();
+
+    var languageInput = document.getElementsByName("language")[0]
+    var licenseInput = document.getElementsByName("license")[0]
+
+    var languages = [
+      "C",
+      "C#",
+      "C++",
+      "Clojure",
+      "Erlang",
+      "Go",
+      "Haskell",
+      "Java",
+      "JavaScript",
+      "Nodejs",
+      "Perl",
+      "PHP",
+      "Python",
+      "Ruby",
+      "Rust",
+      "Scala",
+      "Shell",
+      "Typescript",
+      "Language 1/Language 2"
+    ];
+    var licenses = [
+      "AAL",
+      "AGPL-3.0",
+      "AGPL-3.0-only",
+      "Apache-2.0",
+      "APSL-2.0",
+      "Artistic-2.0",
+      "Beerware",
+      "BSD-2-Clause",
+      "BSD-3-Clause",
+      "CC-BY-NC-SA-3.0",
+      "CC-BY-SA-3.0",
+      "CC-BY-SA-4.0",
+      "CC0-1.0",
+      "CDDL-1.0",
+      "CECILL-B",
+      "CPAL-1.0",
+      "DPL",
+      "ECL-2.0",
+      "EPL-1.0",
+      "GPL-1.0",
+      "GPL-2.0",
+      "GPL-3.0",
+      "GPL-3.0-only",
+      "IPL-1.0",
+      "LGPL-2.1",
+      "LGPL-3.0",
+      "MIT",
+      "MPL-1.1",
+      "MPL-2.0",
+      "Multiple",
+      "OSL-3.0",
+      "Other",
+      "Sendmail",
+      "Unlicense",
+      "WTFPL",
+      "Zlib",
+      "ZPL-2.0"
+    ];
+    $(languageInput).autocomplete({
+      source: languages
+    });
+
+    $(licenseInput).autocomplete({
+      source: licenses
+    });
+
     //Throw in some non free and proprietary dependency symbols
     if (description.slice(-1) != ".") { //Add that pesky . but only if they forget it.
         description += "."
@@ -78,7 +151,7 @@ function liclang (s) {
     return "`" + s + "`";
 };
 function link (n, l) {
-    return "[" + n + "](" + l + ")"; 
+    return "[" + n + "](" + l + ")";
 };
 function logEntry () {
     var list = document.getElementById("formLog");


### PR DESCRIPTION
This PR brings in some changes I have been working on to add tooltips and autocomplete for the license and language inputs on the site.

There are a couple of problems with the code at the moment which I would appreciate advice/direction on as getting back into programming:
* The jQueryUI functions for auto complete and tooltip do not work when jQuery 3.3.1 is used and only work with jQuery 1.12.4 (index.hml - lines 95-99).
* Both the tooltip and autocomplete elements look out of place and are not easily distinguishable.  (See screenshot below)
* The tooltip and autocomplete tips appear at the bottom of the page, unwanted behaviour in my opinion. (See screenshot below)

![awesh dev screenshot](https://user-images.githubusercontent.com/2252004/45887573-f27eec00-bdb3-11e8-8cc5-3d0ae684b4ca.png)

@n8225 